### PR TITLE
WSIO-642 Apply follow to internal links in RTE

### DIFF
--- a/src/main/webapp/apps/websight-rte-extensions/web-resources/components/richtext/plugin/Link/Link.ts
+++ b/src/main/webapp/apps/websight-rte-extensions/web-resources/components/richtext/plugin/Link/Link.ts
@@ -17,15 +17,6 @@
 import { validateEmail } from '../Email/helpers/validateEmail.js';
 import CustomLink from './extension-link.js';
 
-function isInternal(link: string) {
-  if (link.startsWith('/') || link.startsWith('#')) {
-    return true;
-  }
-  const linkHost = new URL(link).hostname;
-  const pageHost = window.location.hostname;
-  return linkHost === pageHost;
-}
-
 const Link = () => ({
   getTipTapExtensions: () => [CustomLink.configure({validate(url) {
       return !validateEmail(url);
@@ -38,19 +29,10 @@ const Link = () => ({
       target
     }) => {
       if (href) {
-        if (isInternal(href)) {
-          editor.chain().focus().extendMarkRange('link').setLink({
-            href,
-            target
-          }).updateAttributes('link', {
-            rel: 'follow',
-          }).run();
-        } else {
-          editor.chain().focus().extendMarkRange('link').setLink({
-            href,
-            target
-          }).run();
-        }
+        editor.chain().focus().extendMarkRange('link').setLink({
+          href,
+          target
+        }).run();
       } else {
         editor.chain().focus().extendMarkRange('link').unsetLink().run();
       }

--- a/src/main/webapp/apps/websight-rte-extensions/web-resources/components/richtext/plugin/Link/Link.ts
+++ b/src/main/webapp/apps/websight-rte-extensions/web-resources/components/richtext/plugin/Link/Link.ts
@@ -17,6 +17,15 @@
 import { validateEmail } from '../Email/helpers/validateEmail.js';
 import CustomLink from './extension-link.js';
 
+function isInternal(link: string) {
+  if (link.startsWith('/') || link.startsWith('#')) {
+    return true;
+  }
+  const linkHost = new URL(link).hostname;
+  const pageHost = window.location.hostname;
+  return linkHost === pageHost;
+}
+
 const Link = () => ({
   getTipTapExtensions: () => [CustomLink.configure({validate(url) {
       return !validateEmail(url);
@@ -29,10 +38,19 @@ const Link = () => ({
       target
     }) => {
       if (href) {
-        editor.chain().focus().extendMarkRange('link').setLink({
-          href,
-          target
-        }).run();
+        if (isInternal(href)) {
+          editor.chain().focus().extendMarkRange('link').setLink({
+            href,
+            target
+          }).updateAttributes('link', {
+            rel: 'follow',
+          }).run();
+        } else {
+          editor.chain().focus().extendMarkRange('link').setLink({
+            href,
+            target
+          }).run();
+        }
       } else {
         editor.chain().focus().extendMarkRange('link').unsetLink().run();
       }

--- a/src/main/webapp/apps/websight-rte-extensions/web-resources/components/richtext/plugin/Link/extension-link.ts
+++ b/src/main/webapp/apps/websight-rte-extensions/web-resources/components/richtext/plugin/Link/extension-link.ts
@@ -30,19 +30,12 @@ const CustomLink = Link.extend({
           protocols: [],
           HTMLAttributes: {
             target: '_blank',
+            rel: 'follow',
             class: null,
           },
           validate: undefined,
         };
-      },
-    addAttributes() {
-      return {
-        ...this.parent?.(),
-        rel: {
-          default: 'noopener noreferrer nofollow',
-        },
-      };
-    },
+      }
 });
 
 export default CustomLink;

--- a/src/main/webapp/apps/websight-rte-extensions/web-resources/components/richtext/plugin/Link/extension-link.ts
+++ b/src/main/webapp/apps/websight-rte-extensions/web-resources/components/richtext/plugin/Link/extension-link.ts
@@ -30,12 +30,19 @@ const CustomLink = Link.extend({
           protocols: [],
           HTMLAttributes: {
             target: '_blank',
-            rel: 'noopener noreferrer nofollow',
             class: null,
           },
           validate: undefined,
         };
       },
+    addAttributes() {
+      return {
+        ...this.parent?.(),
+        rel: {
+          default: 'noopener noreferrer nofollow',
+        },
+      };
+    },
 });
 
 export default CustomLink;


### PR DESCRIPTION
As per the SEO audit internal links need to have `follow` as rel attribute. This change targets links created inside the RichTextEditor to automatically have the correct attribute value based on the link value.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
